### PR TITLE
Fix bug when building from clean repo

### DIFF
--- a/YAFPA/common/global_value.py
+++ b/YAFPA/common/global_value.py
@@ -58,6 +58,9 @@ path = Path(f"{BASEDIR}/.git")  # GIT SHARED
 post = Path(f"{BASEDIR}/_notes")
 img = Path(f"{BASEDIR}/assets/img/")
 
+# The img/ directory may not exist yet if starting from scratch or from one that has not had images yet
+img.mkdir(exist_ok=True)
+
 
 def git_push(COMMIT):
     try:


### PR DESCRIPTION
in the [yet-another-free-publish-alternative](https://github.com/Mara-Li/yet-another-free-publish-alternative/tree/master/assets) repository, there is no "img" folder when you begin.

This change will create the directory under assets if it does not exist yet. It should not affect cases that already have the folder

(This solves the bug I was seeing in #4)